### PR TITLE
feat: add smt-append-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,8 @@ dependencies = [
  "ckb-merkle-mountain-range",
  "ckb-rocksdb",
  "rand_chacha",
- "sparse-merkle-tree",
+ "sparse-merkle-tree 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sparse-merkle-tree 0.6.1 (git+https://github.com/jjyr/sparse-merkle-tree?branch=append-only-pr)",
  "tempfile",
 ]
 
@@ -423,6 +424,16 @@ dependencies = [
  "blake2b-rs",
  "cc",
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "sparse-merkle-tree"
+version = "0.6.1"
+source = "git+https://github.com/jjyr/sparse-merkle-tree?branch=append-only-pr#2b8c59d027bacbe50d2c8e0a1f1ef312aa6f75c9"
+dependencies = [
+ "blake2b-rs",
+ "cc",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 rocksdb = { package = "ckb-rocksdb", version = "0.18", default-features = false, features = ["snappy", "march-native"] }
 sparse-merkle-tree = { version = "0.6.1", features = ["std", "trie"] }
 merkle-mountain-range = { package = "ckb-merkle-mountain-range", git = "https://github.com/quake/merkle-mountain-range", branch = "quake/updatable" }
+append-only-smt = { package = "sparse-merkle-tree", git = "https://github.com/jjyr/sparse-merkle-tree", branch = "append-only-pr" }
 blake2b-rs = "0.2"
 rand_chacha = "0.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use blake2b_rs::{Blake2b, Blake2bBuilder};
 
 pub mod mmr;
 pub mod smt;
+pub mod smt_append_only;
 
 pub trait AccumulatorWriter {
     type Item;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,13 @@
-use std::time::Instant;
 use dca_bench::{
-    mmr::accumulator::MMRAccumulator, smt::accumulator::SMTAccumulator, AccumulatorWriter, OutPoint,
+    mmr::accumulator::MMRAccumulator, smt::accumulator::SMTAccumulator,
+    smt_append_only::accumulator::SMTAppendOnlyAccumulator, AccumulatorWriter, OutPoint,
 };
 use rand_chacha::{
     rand_core::{RngCore, SeedableRng},
     ChaChaRng,
 };
 use rocksdb::{prelude::Open, OptimisticTransaction, OptimisticTransactionDB};
+use std::time::Instant;
 
 macro_rules! bench {
     ($accumulator: ty) => {
@@ -83,6 +84,8 @@ fn main() {
         bench!(SMTAccumulator::<OptimisticTransaction, ()>);
     } else if accumulator_type == "mmr" {
         bench!(MMRAccumulator::<OptimisticTransaction, ()>);
+    } else if accumulator_type == "smt-append-only" {
+        bench!(SMTAppendOnlyAccumulator::<OptimisticTransaction, ()>);
     } else {
         println!("first argument must be smt or mmr");
         std::process::exit(1);

--- a/src/smt_append_only/accumulator.rs
+++ b/src/smt_append_only/accumulator.rs
@@ -1,0 +1,165 @@
+use super::{store::DefaultStore, ZERO_CELL_STATUS};
+use crate::{AccumulatorError, AccumulatorReader, AccumulatorWriter, CellStatus, OutPoint, Proof};
+use append_only_smt::{
+    blake2b::Blake2bHasher, error::Error, traits::Value, MerkleProof, SparseMerkleTree, H256,
+};
+use rocksdb::{
+    prelude::{Delete, Get, Iterate, Put},
+    ReadOptions,
+};
+
+pub struct SMTAppendOnlyAccumulator<'a, DB, WO> {
+    smt: SparseMerkleTree<Blake2bHasher, CellStatus, DefaultStore<'a, DB, WO>>,
+}
+
+impl<'a, DB, WO> SMTAppendOnlyAccumulator<'a, DB, WO>
+where
+    DB: Iterate + Get<ReadOptions> + Delete<WO> + Put<WO>,
+{
+    pub fn new(db: &'a DB) -> Result<Self, Error> {
+        let store = DefaultStore::new(db);
+        let root = store.root_by_sequence(store.sequence()).unwrap_or_default();
+        let smt = SparseMerkleTree::new_with_store(store, root);
+        Ok(SMTAppendOnlyAccumulator { smt })
+    }
+}
+
+impl<'a, DB, WO> AccumulatorWriter for SMTAppendOnlyAccumulator<'a, DB, WO>
+where
+    DB: Iterate + Get<ReadOptions> + Delete<WO> + Put<WO>,
+{
+    type Item = OutPoint;
+    type Commitment = AccumulatorCommitment;
+    type Proof = AccumulatorProof;
+
+    fn add(&mut self, elements: Vec<Self::Item>) -> Result<(), AccumulatorError> {
+        // we don't check if the element exists already, caller should make sure the element is unique
+        let sequence = self.smt.store().sequence();
+        self.smt.update_all(
+            elements
+                .into_iter()
+                .map(|out_point| {
+                    let key = out_point.hash();
+                    (key.into(), CellStatus::new_live(sequence))
+                })
+                .collect(),
+        )?;
+        Ok(())
+    }
+
+    fn delete(&mut self, elements: Vec<Self::Item>) -> Result<(), AccumulatorError> {
+        // we don't check if the element has been deleted already, caller should make sure the element is deleted only once
+        let sequence = self.smt.store().sequence();
+        let mut kvs = Vec::with_capacity(elements.len());
+        for (i, out_point) in elements.iter().enumerate() {
+            let key = out_point.hash();
+            let mut status = self.smt.get(&key.into())?;
+            if status == ZERO_CELL_STATUS {
+                return Err(AccumulatorError::ElementNotFound(i));
+            }
+            status.mark_as_dead(sequence);
+            kvs.push((key.into(), status));
+        }
+
+        self.smt.update_all(kvs)?;
+        Ok(())
+    }
+
+    fn commit(&mut self) -> Result<Self::Commitment, AccumulatorError> {
+        let root = *self.smt.root();
+        let sequence = self.smt.store().sequence();
+        self.smt.store_mut().commit(root)?;
+        Ok(AccumulatorCommitment { root, sequence })
+    }
+}
+
+impl<'a, DB, WO> SMTAppendOnlyAccumulator<'a, DB, WO>
+where
+    DB: Iterate + Get<ReadOptions>,
+{
+    pub fn new_with_sequence(db: &'a DB, sequence: u64) -> Result<Self, Error> {
+        let store = DefaultStore::new_with_sequence(db, sequence);
+        let root = store.root().unwrap_or_default();
+        let smt = SparseMerkleTree::new_with_store(store, root);
+        Ok(SMTAppendOnlyAccumulator { smt })
+    }
+}
+
+impl<'a, DB, WO> AccumulatorReader for SMTAppendOnlyAccumulator<'a, DB, WO>
+where
+    DB: Iterate + Get<ReadOptions>,
+{
+    type Item = OutPoint;
+    type Commitment = AccumulatorCommitment;
+    type Proof = AccumulatorProof;
+
+    fn proof(
+        &self,
+        commitment: Self::Commitment,
+        elements: Vec<Self::Item>,
+    ) -> Result<Self::Proof, AccumulatorError> {
+        let root = self.smt.root();
+        if commitment.root != *root {
+            return Err(AccumulatorError::InvalidCommitment);
+        }
+
+        let mut keys = Vec::with_capacity(elements.len());
+        for (i, out_point) in elements.iter().enumerate() {
+            let key = out_point.hash();
+            let status = self.smt.get(&key.into())?;
+            if status == ZERO_CELL_STATUS {
+                return Err(AccumulatorError::ElementNotFound(i));
+            }
+            keys.push(key.into());
+        }
+
+        let proof = self.smt.merkle_proof(keys)?;
+        Ok(AccumulatorProof { inner: proof })
+    }
+}
+
+#[derive(Clone)]
+pub struct AccumulatorCommitment {
+    root: H256,
+    sequence: u64,
+}
+
+impl AccumulatorCommitment {
+    pub fn root(&self) -> &H256 {
+        &self.root
+    }
+
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
+}
+
+pub struct AccumulatorProof {
+    inner: MerkleProof,
+}
+
+impl Proof for AccumulatorProof {
+    type Item = (OutPoint, CellStatus);
+
+    type Commitment = AccumulatorCommitment;
+
+    fn verify(
+        self,
+        commitment: Self::Commitment,
+        elements: Vec<Self::Item>,
+    ) -> Result<bool, AccumulatorError> {
+        let leaves = elements
+            .into_iter()
+            .map(|(out_point, cell_status)| (out_point.hash().into(), cell_status.to_h256()))
+            .collect();
+        self.inner
+            .verify::<Blake2bHasher>(&commitment.root, leaves)
+            .map_err(Into::into)
+    }
+}
+
+impl From<Error> for AccumulatorError {
+    fn from(err: Error) -> Self {
+        AccumulatorError::InternalError(err.to_string())
+    }
+}

--- a/src/smt_append_only/mod.rs
+++ b/src/smt_append_only/mod.rs
@@ -1,0 +1,29 @@
+use crate::{new_blake2b, CellStatus};
+use append_only_smt::{traits::Value, H256};
+
+pub mod accumulator;
+mod serde;
+mod store;
+#[cfg(test)]
+mod tests;
+
+pub const ZERO_CELL_STATUS: CellStatus = CellStatus {
+    block_numbers: [0u8; 16],
+};
+
+impl Value for CellStatus {
+    fn to_h256(&self) -> H256 {
+        if self.block_numbers == [0u8; 16] {
+            return H256::zero();
+        }
+        let mut buf = [0u8; 32];
+        let mut hasher = new_blake2b();
+        hasher.update(self.block_numbers.as_slice());
+        hasher.finalize(&mut buf);
+        buf.into()
+    }
+
+    fn zero() -> Self {
+        ZERO_CELL_STATUS
+    }
+}

--- a/src/smt_append_only/serde.rs
+++ b/src/smt_append_only/serde.rs
@@ -1,0 +1,151 @@
+use std::convert::TryInto;
+
+use append_only_smt::{merge::MergeValue, BranchNode};
+
+/// Serialize a `BranchNode` into a `Vec<u8>` for use as a key in the key-value store.
+pub fn branch_node_to_vec(node: &BranchNode) -> Vec<u8> {
+    match (&node.left, &node.right) {
+        (MergeValue::Value(left), MergeValue::Value(right)) => {
+            let mut ret = Vec::with_capacity(33);
+            ret.extend_from_slice(&[0]);
+            ret.extend_from_slice(left.as_slice());
+            ret.extend_from_slice(right.as_slice());
+            ret
+        }
+        (
+            MergeValue::Value(left),
+            MergeValue::MergeWithZero {
+                base_node,
+                zero_bits,
+                zero_count,
+                value,
+            },
+        ) => {
+            let mut ret = Vec::with_capacity(130);
+            ret.extend_from_slice(&[1]);
+            ret.extend_from_slice(left.as_slice());
+            ret.extend_from_slice(base_node.as_slice());
+            ret.extend_from_slice(zero_bits.as_slice());
+            ret.extend_from_slice(&[*zero_count]);
+            ret.extend_from_slice(value.as_slice());
+            ret
+        }
+        (
+            MergeValue::MergeWithZero {
+                base_node,
+                zero_bits,
+                zero_count,
+                value,
+            },
+            MergeValue::Value(right),
+        ) => {
+            let mut ret = Vec::with_capacity(130);
+            ret.extend_from_slice(&[2]);
+            ret.extend_from_slice(base_node.as_slice());
+            ret.extend_from_slice(zero_bits.as_slice());
+            ret.extend_from_slice(&[*zero_count]);
+            ret.extend_from_slice(value.as_slice());
+            ret.extend_from_slice(right.as_slice());
+            ret
+        }
+        (
+            MergeValue::MergeWithZero {
+                base_node: l_base_node,
+                zero_bits: l_zero_bits,
+                zero_count: l_zero_count,
+                value: l_value,
+            },
+            MergeValue::MergeWithZero {
+                base_node: r_base_node,
+                zero_bits: r_zero_bits,
+                zero_count: r_zero_count,
+                value: r_value,
+            },
+        ) => {
+            let mut ret = Vec::with_capacity(195);
+            ret.extend_from_slice(&[3]);
+            ret.extend_from_slice(l_base_node.as_slice());
+            ret.extend_from_slice(l_zero_bits.as_slice());
+            ret.extend_from_slice(&[*l_zero_count]);
+            ret.extend_from_slice(l_value.as_slice());
+            ret.extend_from_slice(r_base_node.as_slice());
+            ret.extend_from_slice(r_zero_bits.as_slice());
+            ret.extend_from_slice(&[*r_zero_count]);
+            ret.extend_from_slice(r_value.as_slice());
+            ret
+        }
+    }
+}
+
+/// Deserialize a `BranchNode` from a slice that was previously serialized with `branch_node_to_vec`.
+pub fn slice_to_branch_node(slice: &[u8]) -> BranchNode {
+    match slice[0] {
+        0 => {
+            let left: [u8; 32] = slice[1..33].try_into().expect("checked slice");
+            let right: [u8; 32] = slice[33..65].try_into().expect("checked slice");
+            BranchNode {
+                left: MergeValue::Value(left.into()),
+                right: MergeValue::Value(right.into()),
+            }
+        }
+        1 => {
+            let left: [u8; 32] = slice[1..33].try_into().expect("checked slice");
+            let base_node: [u8; 32] = slice[33..65].try_into().expect("checked slice");
+            let zero_bits: [u8; 32] = slice[65..97].try_into().expect("checked slice");
+            let zero_count = slice[97];
+            let value: [u8; 32] = slice[98..].try_into().expect("checked slide");
+            BranchNode {
+                left: MergeValue::Value(left.into()),
+                right: MergeValue::MergeWithZero {
+                    base_node: base_node.into(),
+                    zero_bits: zero_bits.into(),
+                    zero_count,
+                    value: value.into()
+                },
+            }
+        }
+        2 => {
+            let base_node: [u8; 32] = slice[1..33].try_into().expect("checked slice");
+            let zero_bits: [u8; 32] = slice[33..65].try_into().expect("checked slice");
+            let zero_count = slice[65];
+            let value: [u8; 32] = slice[66..98].try_into().expect("checked slice");
+            let right: [u8; 32] = slice[98..].try_into().expect("checked slice");
+            BranchNode {
+                left: MergeValue::MergeWithZero {
+                    base_node: base_node.into(),
+                    zero_bits: zero_bits.into(),
+                    zero_count,
+                    value: value.into()
+                },
+                right: MergeValue::Value(right.into()),
+            }
+        }
+        3 => {
+            let l_base_node: [u8; 32] = slice[1..33].try_into().expect("checked slice");
+            let l_zero_bits: [u8; 32] = slice[33..65].try_into().expect("checked slice");
+            let l_zero_count = slice[65];
+            let l_value: [u8; 32] = slice[66..98].try_into().expect("checked slice");
+            let r_base_node: [u8; 32] = slice[98..130].try_into().expect("checked slice");
+            let r_zero_bits: [u8; 32] = slice[130..162].try_into().expect("checked slice");
+            let r_zero_count = slice[162];
+            let r_value: [u8; 32] = slice[163..].try_into().expect("checked slice");
+            BranchNode {
+                left: MergeValue::MergeWithZero {
+                    base_node: l_base_node.into(),
+                    zero_bits: l_zero_bits.into(),
+                    zero_count: l_zero_count,
+                    value: l_value.into()
+                },
+                right: MergeValue::MergeWithZero {
+                    base_node: r_base_node.into(),
+                    zero_bits: r_zero_bits.into(),
+                    zero_count: r_zero_count,
+                    value: r_value.into()
+                },
+            }
+        }
+        _ => {
+            unreachable!()
+        }
+    }
+}

--- a/src/smt_append_only/store.rs
+++ b/src/smt_append_only/store.rs
@@ -1,0 +1,169 @@
+use std::marker::PhantomData;
+
+use append_only_smt::{
+    error::Error,
+    traits::{StoreReadOps, StoreWriteOps, Value},
+    BranchNode, H256,
+};
+use rocksdb::prelude::*;
+
+use super::serde::{branch_node_to_vec, slice_to_branch_node};
+
+const SEQUENCE_KEY: &[u8] = b"SEQUENCE";
+const SEQUENCE_TO_ROOT_KEY: &[u8] = b"SEQUENCE_TO_ROOT";
+
+/// A SMT `Store` implementation backed by a RocksDB database, using the default column family and supports historical queries.
+pub struct DefaultStore<'a, DB, WO> {
+    // The RocksDB database which stores the data, can be a `DB` / `OptimisticTransactionDB` / `Snapshot` etc.
+    inner: &'a DB,
+    // The sequence number is used to support historical queries.
+    sequence: u64,
+    // A generic write options, can be a `WriteOptions` / `()` etc.
+    write_options: PhantomData<WO>,
+}
+
+impl<'a, DB, WO> DefaultStore<'a, DB, WO>
+where
+    DB: Get<ReadOptions>,
+{
+    pub fn new(db: &'a DB) -> Self {
+        let sequence = db
+            .get(SEQUENCE_KEY)
+            .expect("init sequence number should be ok")
+            .map(|v| {
+                u64::from_be_bytes(
+                    v.as_ref()
+                        .try_into()
+                        .expect("sequence number should be 8 bytes"),
+                )
+            })
+            .unwrap_or(0);
+        DefaultStore {
+            inner: db,
+            sequence,
+            write_options: PhantomData,
+        }
+    }
+
+    pub fn new_with_sequence(db: &'a DB, sequence: u64) -> Self {
+        let stored_sequence = db
+            .get(SEQUENCE_KEY)
+            .expect("init sequence number should be ok")
+            .map(|v| {
+                u64::from_be_bytes(
+                    v.as_ref()
+                        .try_into()
+                        .expect("sequence number should be 8 bytes"),
+                )
+            })
+            .unwrap_or(0);
+        if sequence > stored_sequence {
+            panic!("sequence number: {} should be less than or equal to the stored sequence number: {}", sequence, stored_sequence);
+        }
+        DefaultStore {
+            inner: db,
+            sequence,
+            write_options: PhantomData,
+        }
+    }
+
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
+}
+
+impl<'a, DB, WO> DefaultStore<'a, DB, WO>
+where
+    DB: Get<ReadOptions>,
+{
+    fn get(&self, key: &[u8]) -> Option<Box<[u8]>> {
+        self.inner
+            .get(key)
+            .expect("get should be ok")
+            .map(|v| (*v).into())
+    }
+
+    pub fn root(&self) -> Option<H256> {
+        self.root_by_sequence(self.sequence)
+    }
+
+    pub fn root_by_sequence(&self, seq: u64) -> Option<H256> {
+        let key = [SEQUENCE_TO_ROOT_KEY, seq.to_be_bytes().as_ref()].concat();
+        let v = self.get(&key)?;
+        let buf: [u8; 32] = (*v).try_into().expect("root should be 32 bytes");
+        Some(buf.into())
+    }
+}
+
+impl<'a, DB, WO> DefaultStore<'a, DB, WO>
+where
+    DB: Delete<WO> + Put<WO>,
+{
+    fn put<V: AsRef<[u8]>>(&mut self, key: &[u8], value: V) -> Result<(), Error> {
+        self.inner
+            .put(key, value)
+            .map_err(|e| Error::Store(e.to_string()))
+    }
+
+    pub fn commit(&mut self, root: H256) -> Result<(), Error> {
+        let key = [SEQUENCE_TO_ROOT_KEY, self.sequence.to_be_bytes().as_ref()].concat();
+        self.inner
+            .put(key, root.as_slice())
+            .map_err(|e| Error::Store(e.to_string()))?;
+        self.inner
+            .put(SEQUENCE_KEY, self.sequence.to_be_bytes())
+            .map_err(|e| Error::Store(e.to_string()))?;
+        self.sequence += 1;
+        Ok(())
+    }
+}
+
+impl<'a, V, DB, WO> StoreReadOps<V> for DefaultStore<'a, DB, WO>
+where
+    V: Value + From<Box<[u8]>>,
+    DB: Get<ReadOptions>,
+{
+    fn get_branch(&self, branch_key: &H256) -> Result<Option<BranchNode>, Error> {
+        let slice = self.get(branch_key.as_slice());
+        match slice {
+            Some(s) if s.is_empty() => Ok(None),
+            Some(s) => Ok(Some(slice_to_branch_node(&s))),
+            None => Ok(None),
+        }
+    }
+
+    fn get_leaf(&self, leaf_key: &H256) -> Result<Option<V>, Error> {
+        let slice = self.get(leaf_key.as_slice());
+        match slice {
+            Some(s) if s.is_empty() => Ok(None),
+            Some(s) => Ok(Some(V::from(s))),
+            None => Ok(None),
+        }
+    }
+}
+
+impl<'a, V, DB, WO> StoreWriteOps<V> for DefaultStore<'a, DB, WO>
+where
+    V: Value + AsRef<[u8]> + From<Box<[u8]>>,
+    DB: Iterate + Delete<WO> + Put<WO>,
+{
+    fn insert_branch(&mut self, node_key: H256, branch: BranchNode) -> Result<(), Error> {
+        self.put(node_key.as_slice(), &branch_node_to_vec(&branch))
+    }
+
+    fn insert_leaf(&mut self, leaf_key: H256, leaf: V) -> Result<(), Error> {
+        self.put(leaf_key.as_slice(), leaf)
+    }
+
+    fn remove_branch(&mut self, node_key: &H256) -> Result<(), Error> {
+        self.inner
+            .put(node_key.as_slice(), [])
+            .map_err(|e| Error::Store(e.to_string()))
+    }
+
+    fn remove_leaf(&mut self, leaf_key: &H256) -> Result<(), Error> {
+        self.inner
+            .put(leaf_key.as_slice(), [])
+            .map_err(|e| Error::Store(e.to_string()))
+    }
+}

--- a/src/smt_append_only/tests.rs
+++ b/src/smt_append_only/tests.rs
@@ -1,0 +1,216 @@
+use append_only_smt::{blake2b::Blake2bHasher, traits::Value, SparseMerkleTree, H256};
+use rocksdb::{prelude::Open, OptimisticTransactionDB};
+use tempfile::{Builder, TempDir};
+
+use crate::{new_blake2b, AccumulatorReader, AccumulatorWriter, CellStatus, OutPoint, Proof};
+
+use super::{accumulator::SMTAppendOnlyAccumulator, store::DefaultStore};
+
+type DefaultStoreSMT<'a, DB, WO> = SparseMerkleTree<Blake2bHasher, Word, DefaultStore<'a, DB, WO>>;
+
+#[derive(Default, Clone)]
+pub struct Word(String);
+
+impl Value for Word {
+    fn to_h256(&self) -> H256 {
+        if self.0.is_empty() {
+            return H256::zero();
+        }
+        let mut buf = [0u8; 32];
+        let mut hasher = new_blake2b();
+        hasher.update(self.0.as_bytes());
+        hasher.finalize(&mut buf);
+        buf.into()
+    }
+
+    fn zero() -> Self {
+        Default::default()
+    }
+}
+
+impl From<Box<[u8]>> for Word {
+    fn from(s: Box<[u8]>) -> Self {
+        Word(String::from_utf8(s.to_vec()).expect("stored value is utf8"))
+    }
+}
+
+impl AsRef<[u8]> for Word {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+// return temp dir also to make sure it's not dropped automatically
+fn open_db() -> (OptimisticTransactionDB, TempDir) {
+    let tmp_dir = Builder::new().tempdir().unwrap();
+    (
+        OptimisticTransactionDB::open_default(tmp_dir.path()).unwrap(),
+        tmp_dir,
+    )
+}
+
+#[test]
+fn test_historical_queries() {
+    let kvs = "The quick brown fox jumps over the lazy dog"
+        .split_whitespace()
+        .enumerate()
+        .map(|(i, word)| {
+            let mut buf = [0u8; 32];
+            let mut hasher = new_blake2b();
+            hasher.update(&(i as u32).to_le_bytes());
+            hasher.finalize(&mut buf);
+            (buf.into(), Word(word.to_string()))
+        })
+        .collect::<Vec<(H256, Word)>>();
+
+    let (db, _tmp_dir) = open_db();
+    let tx = db.transaction_default();
+    let rocksdb_store = DefaultStore::new(&tx);
+    let root = rocksdb_store
+        .root_by_sequence(rocksdb_store.sequence())
+        .unwrap_or_default();
+    let mut smt = DefaultStoreSMT::new_with_store(rocksdb_store, root);
+
+    smt.update(kvs[0].0, kvs[0].1.clone()).unwrap();
+    smt.update(kvs[1].0, kvs[1].1.clone()).unwrap();
+    smt.update(kvs[2].0, kvs[2].1.clone()).unwrap();
+    let root1 = smt.root().clone();
+    smt.store_mut().commit(root1).unwrap();
+
+    smt.update(kvs[3].0, kvs[3].1.clone()).unwrap();
+    smt.update(kvs[4].0, kvs[4].1.clone()).unwrap();
+    smt.update(kvs[5].0, kvs[5].1.clone()).unwrap();
+    let root2 = smt.root().clone();
+    smt.store_mut().commit(root2).unwrap();
+
+    // delete key 1
+    smt.update(kvs[1].0, Word("".to_string())).unwrap();
+    // update key 4
+    smt.update(kvs[4].0, Word("JUMPS".to_string())).unwrap();
+    smt.update(kvs[6].0, kvs[6].1.clone()).unwrap();
+    smt.update(kvs[7].0, kvs[7].1.clone()).unwrap();
+    let root3 = smt.root().clone();
+    smt.store_mut().commit(root3).unwrap();
+
+    smt.update(kvs[8].0, kvs[8].1.clone()).unwrap();
+    let root4 = smt.root().clone();
+    smt.store_mut().commit(root4).unwrap();
+    tx.commit().unwrap();
+
+    let snapshot = db.snapshot();
+    let rocksdb_store = DefaultStore::<_, ()>::new_with_sequence(&snapshot, 0);
+    let smt = {
+        let default_root = rocksdb_store.root().unwrap();
+        DefaultStoreSMT::new_with_store(rocksdb_store, default_root)
+    };
+    let root = smt.root().clone();
+    assert_eq!(root1, root);
+    let proof = smt.merkle_proof(vec![kvs[0].0]).unwrap();
+    assert!(proof
+        .verify::<Blake2bHasher>(&root, vec![(kvs[0].0, kvs[0].1.to_h256())])
+        .unwrap());
+
+    let rocksdb_store = DefaultStore::<_, ()>::new_with_sequence(&snapshot, 1);
+    let smt = {
+        let default_root = rocksdb_store.root().unwrap();
+        DefaultStoreSMT::new_with_store(rocksdb_store, default_root)
+    };
+    let root = smt.root().clone();
+    assert_eq!(root2, root);
+    let proof = smt.merkle_proof(vec![kvs[0].0, kvs[3].0]).unwrap();
+    assert!(proof
+        .verify::<Blake2bHasher>(
+            &root,
+            vec![
+                (kvs[0].0, kvs[0].1.to_h256()),
+                (kvs[3].0, kvs[3].1.to_h256())
+            ]
+        )
+        .unwrap());
+
+    let rocksdb_store = DefaultStore::<_, ()>::new_with_sequence(&snapshot, 2);
+    let smt = {
+        let default_root = rocksdb_store.root().unwrap();
+        DefaultStoreSMT::new_with_store(rocksdb_store, default_root)
+    };
+    let root = smt.root().clone();
+    assert_eq!(root3, root);
+    let proof = smt.merkle_proof(vec![kvs[1].0, kvs[4].0]).unwrap();
+    assert!(proof
+        .verify::<Blake2bHasher>(
+            &root,
+            vec![
+                (kvs[1].0, H256::zero()),
+                (kvs[4].0, Word("JUMPS".to_string()).to_h256())
+            ]
+        )
+        .unwrap());
+
+    let rocksdb_store = DefaultStore::<_, ()>::new(&snapshot);
+    let smt = {
+        let default_root = rocksdb_store.root().unwrap();
+        DefaultStoreSMT::new_with_store(rocksdb_store, default_root)
+    };
+    let root = smt.root().clone();
+    assert_eq!(root4, root);
+}
+
+#[test]
+fn test_accumulator() {
+    let (db, _tmp_dir) = open_db();
+    let tx = db.transaction_default();
+    let mut accumulator = SMTAppendOnlyAccumulator::new(&tx).unwrap();
+
+    let out_point_1 = OutPoint {
+        tx_hash: [1u8; 32],
+        index: 0,
+    };
+
+    let out_point_2 = OutPoint {
+        tx_hash: [2u8; 32],
+        index: 0,
+    };
+
+    let out_point_3 = OutPoint {
+        tx_hash: [3u8; 32],
+        index: 0,
+    };
+
+    accumulator
+        .add(vec![out_point_1.clone(), out_point_2.clone()])
+        .unwrap();
+    let commitment1 = accumulator.commit().unwrap();
+
+    accumulator.add(vec![out_point_3.clone()]).unwrap();
+    let commitment2 = accumulator.commit().unwrap();
+
+    accumulator.delete(vec![out_point_2.clone()]).unwrap();
+    let commitment3 = accumulator.commit().unwrap();
+
+    tx.commit().unwrap();
+
+    let snapshot = db.snapshot();
+    let accumulator = SMTAppendOnlyAccumulator::<_, ()>::new_with_sequence(&snapshot, 0).unwrap();
+    let proof1 = accumulator
+        .proof(commitment1.clone(), vec![out_point_1.clone()])
+        .unwrap();
+    assert!(proof1
+        .verify(commitment1, vec![(out_point_1, CellStatus::new_live(0))])
+        .unwrap());
+
+    let accumulator = SMTAppendOnlyAccumulator::<_, ()>::new_with_sequence(&snapshot, 1).unwrap();
+    let proof2 = accumulator
+        .proof(commitment2.clone(), vec![out_point_3.clone()])
+        .unwrap();
+    assert!(proof2
+        .verify(commitment2, vec![(out_point_3, CellStatus::new_live(1))])
+        .unwrap());
+
+    let accumulator = SMTAppendOnlyAccumulator::<_, ()>::new_with_sequence(&snapshot, 2).unwrap();
+    let proof3 = accumulator
+        .proof(commitment3.clone(), vec![out_point_2.clone()])
+        .unwrap();
+    assert!(proof3
+        .verify(commitment3, vec![(out_point_2, CellStatus::new_dead(0, 2))])
+        .unwrap());
+}


### PR DESCRIPTION
```
## Size
3.4G    /tmp/smt-append-only
603M    /tmp/mmr


## MMR
~~~~
elapsed 183115 millis, finished block: 98999
elapsed 183286 millis, finished block: 99099
elapsed 183455 millis, finished block: 99199
elapsed 183633 millis, finished block: 99299
elapsed 183805 millis, finished block: 99399
elapsed 183978 millis, finished block: 99499
elapsed 184151 millis, finished block: 99599
elapsed 184323 millis, finished block: 99699
elapsed 184500 millis, finished block: 99799
elapsed 184678 millis, finished block: 99899
elapsed 184853 millis, finished block: 99999

### SMT append only
~~~
elapsed 245239 millis, finished block: 98799
elapsed 245591 millis, finished block: 98899
elapsed 245938 millis, finished block: 98999
elapsed 246298 millis, finished block: 99099
elapsed 246658 millis, finished block: 99199
elapsed 246968 millis, finished block: 99299
elapsed 247286 millis, finished block: 99399
elapsed 247632 millis, finished block: 99499
elapsed 247965 millis, finished block: 99599
elapsed 248301 millis, finished block: 99699
elapsed 248637 millis, finished block: 99799
elapsed 248970 millis, finished block: 99899
elapsed 249310 millis, finished block: 99999
```